### PR TITLE
Removed unnecessary semicolon

### DIFF
--- a/sulis_module/src/lib.rs
+++ b/sulis_module/src/lib.rs
@@ -437,7 +437,7 @@ impl Module {
             module.scripts.clear();
             module.generators.clear();
             module.features.clear();
-            module.terrain_rules = None;;
+            module.terrain_rules = None;
             module.terrain_kinds.clear();
             module.wall_rules = None;
             module.wall_kinds.clear();

--- a/sulis_view/src/character_builder/cosmetic_selector_pane.rs
+++ b/sulis_view/src/character_builder/cosmetic_selector_pane.rs
@@ -305,7 +305,7 @@ impl WidgetKind for CosmeticSelectorPane {
             .state
             .add_callback(Callback::new(Rc::new(|widget, _| {
                 let (parent, cosmetic_pane) = Widget::parent_mut::<CosmeticSelectorPane>(widget);
-                cosmetic_pane.sex = Sex::Female;
+                cosmetic_pane.sex = Sex::Male;
                 cosmetic_pane.beard_index = None;
                 parent.borrow_mut().invalidate_children();
             })));


### PR DESCRIPTION
```rust
warning: unnecessary trailing semicolon
   --> sulis_module\src\lib.rs:440:41
    |
440 |             module.terrain_rules = None;;
    |                                         ^ help: remove this semicolon
    |
    = note: `#[warn(redundant_semicolon)]` on by default
```

Upd: Added #128 fix