### PR TITLE
修复编译时警告问题

### DIFF
--- a/sulis_core/src/widgets/label.rs
+++ b/sulis_core/src/widgets/label.rs
@@ -62,7 +62,7 @@ impl Label {
 
         let x = match widget.state.text_params.horizontal_alignment {
             HorizontalAlignment::Left => x,
-            HorizontalAlignment::Center => (x + (w - len) / 2.0),
+            HorizontalAlignment::Center => x + (w - len) / 2.0,
             HorizontalAlignment::Right => x + w - len,
         };
 


### PR DESCRIPTION
warning: unnecessary parentheses around match arm expression
  --> sulis_core\src\widgets\label.rs:65:44
   |
65 |             HorizontalAlignment::Center => (x + (w - len) / 2.0),
   |                                            ^                   ^
   |