### PR TITLE
Enabled vsync.

### DIFF
--- a/sulis_core/src/io/glium_adapter.rs
+++ b/sulis_core/src/io/glium_adapter.rs
@@ -356,7 +356,8 @@ fn try_get_display(
         .with_decorations(decorations)
         .with_fullscreen(fullscreen.clone());
     let context = ContextBuilder::new()
-        .with_pixel_format(24, 8);
+        .with_pixel_format(24, 8)
+        .with_vsync(true);
 
     match context.build_windowed(window, event_loop) {
         Ok(windowed_context) => {
@@ -381,7 +382,8 @@ fn try_get_display(
         .with_fullscreen(fullscreen);
     let context = ContextBuilder::new()
         .with_hardware_acceleration(None)
-        .with_pixel_format(24, 8);
+        .with_pixel_format(24, 8)
+        .with_vsync(true);
     let windowed_context = context.build_windowed(window, event_loop)?;
 
     let display = glium::Display::from_gl_window(windowed_context)?;


### PR DESCRIPTION
Enabled vsync in glium to lower the framerate to what the monitor supports. Drops fps from ~300 down to 60 on laptop with dual intel/nvidia gpus.